### PR TITLE
Implemented support for all fzf layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fzf-wrapped"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12f33c76302b231bc316380587156a81656f30331e97246c367ea88ba8c8d55"
+checksum = "4f2bc867750ff6dd5c061ca65b23760181a89b16b2d1b96ca182d7f3b15fdfee"
 dependencies = [
  "derive_builder",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories=["command-line-utilities","filesystem"]
 casual = "0.2.0"
 colored = "2.0.4"
 dirs = "5.0.1"
-fzf-wrapped = "0.1.0"
+fzf-wrapped = "0.1.2"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.8.6"
 which = "5.0.0"

--- a/src/config/fzf.rs
+++ b/src/config/fzf.rs
@@ -1,52 +1,52 @@
 //! This module contains the logic for fzf configuration
 
+use fzf_wrapped::Layout;
 use serde::Deserialize;
-
-const DEFAULT_REVERSE_LAYOUT: bool = true;
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct FzfConfig {
     /// Whether fzf should have the reverse layout
     ///
     /// Default: `true`
-    reverse_layout: Option<bool>, // TODO: Allows user's to choose from any of the three fzf
-                                  // layouts by passing in a string
+    layout: Option<String>,
 }
 
 impl FzfConfig {
     /// Whether fzf should have the reverse layout
     ///
     /// Default: `true`
-    pub fn reverse_layout(&self) -> bool {
-        self.reverse_layout.unwrap_or(DEFAULT_REVERSE_LAYOUT)
+    pub fn layout(&self) -> Layout {
+        match self.layout.clone() {
+            Some(layout) => Layout::from(layout),
+            None => Layout::default(),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{fzf::DEFAULT_REVERSE_LAYOUT, WorkflowsConfig};
+    use crate::config::WorkflowsConfig;
+    use fzf_wrapped::Layout;
 
     #[test]
-    fn reverse_layout_works() {
+    fn layout_works() {
         let toml = "\
-[fzf]
-reverse_layout = true";
+                    [fzf]\n\
+                    layout = 'reverse'";
 
-        let config: WorkflowsConfig = toml::from_str(toml).expect("Failed to unwrap toml");
+        let config: WorkflowsConfig = toml::from_str(toml).unwrap();
 
-        assert_eq!(config.fzf().reverse_layout, Some(true))
+        assert_eq!(config.fzf().layout(), Layout::Reverse);
     }
 
     #[test]
-    fn default_reverse_layout_works() {
-        // The toml contains [fzf] so that the field is some on the WorkflowsConfig
-        // allowing the testing of the reverse_layout field to be `None`
+    fn default_layout_works() {
         let toml = "[fzf]";
 
-        let config: WorkflowsConfig = toml::from_str(toml).expect("Failed to unwrap toml");
+        let config: WorkflowsConfig = toml::from_str(toml).unwrap();
 
-        assert_eq!(config.fzf.clone().unwrap().reverse_layout, None);
+        assert_eq!(config.fzf().layout, None);
 
-        assert_eq!(config.fzf().reverse_layout(), DEFAULT_REVERSE_LAYOUT)
+        assert_eq!(config.fzf().layout(), Layout::default())
     }
 }

--- a/src/intergrations/fzf.rs
+++ b/src/intergrations/fzf.rs
@@ -22,14 +22,13 @@ use crate::repo::Repo;
 /// A tuple with the first element being the name of the project selected, and the vec of Repos
 /// being the merged list of local and github repos
 pub fn run_fzf(prompt: &str, delete_mode: bool, config: &WorkflowsConfig) -> (String, Vec<Repo>) {
-    let mut fzf_builder = Fzf::builder();
-    fzf_builder.prompt(prompt).color(Color::Sixteen).ansi(true);
-
-    if config.fzf().reverse_layout() {
-        fzf_builder.layout(Layout::Reverse);
-    }
-
-    let mut fzf = fzf_builder.build().unwrap();
+    let mut fzf = Fzf::builder()
+        .prompt(prompt)
+        .color(Color::Sixteen)
+        .ansi(true)
+        .layout(config.fzf().layout())
+        .build()
+        .unwrap();
 
     fzf.run().expect("Failed to run fzf");
 


### PR DESCRIPTION
Users can now configure fzf to use any of the three fzf layouts using
the `layout` option under the `fzf` table. The configuration as always
is best effort, so if the option is invalid the default is chosen