### PR TITLE
feat: delete command accepts project as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ With confirmation the project will be deleted.
 Deleting using `workflows --delete` deletes the tmuxinator config 
 as well as the project in the projects directory.
 
+#### Deleting a known project
+
+If you know the exact name of the project you're wanting to
+delete, you can also use `workflows --delete <PROJECT_NAME>`.
+
+For example, if you wanted to delete a project called `test-proj`,
+you could run `workflows --delete test-proj`. This bypasses fzf.
+
 ### Cloning a project
 
 Workflows can also be used to clone git repos using `workflows --clone`,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,8 @@ fn main() -> io::Result<()> {
     let config = config::get_config().unwrap_or_default();
 
     if args.contains(&"--delete".to_string()) || args.contains(&"-d".to_string()) {
-        return commands::delete_project(config);
+        let project = args.get(2).cloned();
+        return commands::delete_project(project, config);
     }
 
     if args.contains(&"--new".to_string()) || args.contains(&"-n".to_string()) {


### PR DESCRIPTION
Users can now delete projects without having to select them from `fzf` by passing in the projects name as an argument to `--delete`

- Added functionality
- Added docs

Close #9 