### PR TITLE
feat!: add support for multiple project dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ default configuration is used
 
 ```toml
 [general]
-programs_dir="Projects/"
+projects_dirs=["Projects/"]
 open_new_projects=true
 
 [fzf]
@@ -210,7 +210,7 @@ start_commands=["nvim ."]
 
 | Option | Purpose | Default Value |
 | ------ | ------- | ------------- |
-| `projects_dir` | Where `workflows` should look for projects. Path is relative to $HOME | `"Projects/"` |
+| `projects_dir` | Where `workflows` should look for projects. Paths are relative to $HOME | `["Projects/]"` |
 | `open_new_projects` | Whether projects should be opened after they have been created with `--create` | `true` |
 
 ### fzf configuration

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -11,6 +11,6 @@ pub fn git_clone(url: Option<String>, config: &WorkflowsConfig) -> Option<Repo> 
     Some(Repo::new(
         project_name,
         true,
-        Some(project_dir.to_string_lossy().to_string()),
+        Some(project_dir),
     ))
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -8,9 +8,5 @@ pub fn git_clone(url: Option<String>, config: &WorkflowsConfig) -> Option<Repo> 
     // Parsing the url
     let project_name = url?.split('/').last()?.replace(".git", "");
 
-    Some(Repo::new(
-        project_name,
-        true,
-        Some(project_dir),
-    ))
+    Some(Repo::new(project_name, true, Some(project_dir)))
 }

--- a/src/commands/clone.rs
+++ b/src/commands/clone.rs
@@ -1,12 +1,16 @@
-use crate::config::general::GeneralConfig;
+use crate::config::WorkflowsConfig;
 use crate::{intergrations, repo::Repo};
 
 /// Attempts to clone the git repo at the given url into the user's project folder
-pub fn git_clone(url: Option<String>, config: GeneralConfig) -> Option<Repo> {
-    let _ = intergrations::git::clone_repo(&url.clone()?, &config);
+pub fn git_clone(url: Option<String>, config: &WorkflowsConfig) -> Option<Repo> {
+    let project_dir = intergrations::git::clone_repo(&url.clone()?, config).ok()?;
 
     // Parsing the url
     let project_name = url?.split('/').last()?.replace(".git", "");
 
-    Some(Repo::new(project_name, true, config.projects_dir()))
+    Some(Repo::new(
+        project_name,
+        true,
+        Some(project_dir.to_string_lossy().to_string()),
+    ))
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -51,12 +51,8 @@ pub fn delete_project(project: Option<String>, config: WorkflowsConfig) -> io::R
 /// - `repo`   The project to delete
 /// - `config` The user's config
 fn delete_local_project(repo: &Repo, config: WorkflowsConfig) -> io::Result<()> {
-    let binding = repo
-        .get_project_root()
-        .expect("Failed to get project root");
-    let project_root = binding
-        .to_str()
-        .expect("Failed to get str");
+    let binding = repo.get_project_root().expect("Failed to get project root");
+    let project_root = binding.to_str().expect("Failed to get str");
 
     println!("Deleting project located at {}\n", project_root.bold());
 

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -51,6 +51,15 @@ pub fn delete_project(project: Option<String>, config: WorkflowsConfig) -> io::R
 /// - `repo`   The project to delete
 /// - `config` The user's config
 fn delete_local_project(repo: &Repo, config: WorkflowsConfig) -> io::Result<()> {
+    let binding = repo
+        .get_project_root()
+        .expect("Failed to get project root");
+    let project_root = binding
+        .to_str()
+        .expect("Failed to get str");
+
+    println!("Deleting project located at {}\n", project_root.bold());
+
     if config.git().check_push() {
         // Checking if the project has been pushed
         print!("[{}] main pushed...", "~".bright_yellow());
@@ -100,12 +109,7 @@ fn delete_local_project(repo: &Repo, config: WorkflowsConfig) -> io::Result<()> 
     }
     println!("Deleting tmuxinator config");
     intergrations::tmuxinator::delete_tmuxinator(repo)?;
-    println!(
-        "Deleting project located at {}",
-        repo.get_project_root()
-            .expect("Failed to get project root")
-            .to_str().expect("Failed to get str")
-    );
+    println!("Deleting project located at {}", project_root);
     delete_project_dir(repo)?;
 
     println!("Deleted {}!", repo.name());

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -22,7 +22,7 @@ use super::get_local_projects;
 pub fn delete_project(project: Option<String>, config: WorkflowsConfig) -> io::Result<()> {
     // User has passed in a project with an argument
     if let Some(project) = project {
-        let local_projects = get_local_projects(config.general().projects_dir());
+        let local_projects = get_local_projects(config.general().projects_dirs());
 
         let local_repo = local_projects.iter().find(|x| x.name() == project);
 
@@ -113,6 +113,8 @@ fn delete_local_project(repo: &Repo, config: WorkflowsConfig) -> io::Result<()> 
 ///
 /// - `project` The project to delete
 fn delete_project_dir(project: &Repo) -> io::Result<()> {
-    fs::remove_dir_all(project.get_project_root())?;
-    Ok(())
+    match project.get_project_root() {
+        Some(project_root) => fs::remove_dir_all(project_root),
+        None => Ok(()),
+    }
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -100,7 +100,12 @@ fn delete_local_project(repo: &Repo, config: WorkflowsConfig) -> io::Result<()> 
     }
     println!("Deleting tmuxinator config");
     intergrations::tmuxinator::delete_tmuxinator(repo)?;
-    println!("Deleting project from ~/Projects/");
+    println!(
+        "Deleting project located at {}",
+        repo.get_project_root()
+            .expect("Failed to get project root")
+            .to_str().expect("Failed to get str")
+    );
     delete_project_dir(repo)?;
 
     println!("Deleted {}!", repo.name());

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 
 use crate::{
     config::{templates::WorkspaceTemplate, WorkflowsConfig},
-    intergrations::fzf::{get_template, get_project_dir},
+    intergrations::fzf::{get_project_dir, get_template},
 };
 
 /// Creates a new project in the selected project directory
@@ -30,7 +30,7 @@ pub fn new_project(
     if let Some(project_name) = project_name {
         let projects_dir = match get_project_dir(&config) {
             Some(projects_dir) => projects_dir,
-            None => return Ok(None)
+            None => return Ok(None),
         };
 
         let project_dir = dirs::home_dir()

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -9,17 +9,33 @@ use colored::Colorize;
 
 use crate::{
     config::{templates::WorkspaceTemplate, WorkflowsConfig},
-    intergrations::fzf::get_template,
+    intergrations::fzf::{get_template, get_project_dir},
 };
 
+/// Creates a new project in the selected project directory
+///
+/// # Parameters
+///
+/// - `project_name` The name of the project to create
+/// - `config` The users config
+///
+/// # Returns
+///
+/// A tuple in the format (project_name, projects_dir), otherwise `None` if the user didn't create
+/// a project
 pub fn new_project(
     project_name: Option<String>,
     config: WorkflowsConfig,
-) -> io::Result<Option<String>> {
+) -> io::Result<Option<(String, String)>> {
     if let Some(project_name) = project_name {
+        let projects_dir = match get_project_dir(&config) {
+            Some(projects_dir) => projects_dir,
+            None => return Ok(None)
+        };
+
         let project_dir = dirs::home_dir()
             .expect("Failed to get home directory")
-            .join(config.general().projects_dir())
+            .join(projects_dir.clone())
             .join(&project_name);
 
         fs::create_dir_all(&project_dir)?;
@@ -27,7 +43,7 @@ pub fn new_project(
         let template = get_template(config);
         run_template(template, &project_name, project_dir)?;
 
-        return Ok(Some(project_name));
+        return Ok(Some((project_name, projects_dir)));
     }
 
     Ok(None)

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -2,6 +2,7 @@ use std::{fs, io};
 
 use crate::config::WorkflowsConfig;
 use crate::intergrations;
+use crate::intergrations::fzf::get_project_dir;
 use crate::repo::Repo;
 
 /// Runs fzf with the user's projects, opening the one they select in a tmuxinator session
@@ -23,7 +24,12 @@ pub fn open_project(config: WorkflowsConfig) -> io::Result<()> {
             {
                 return Ok(());
             }
-            intergrations::gh::clone_repo(&selected_project, config.general().projects_dir())?;
+
+            match get_project_dir(&config) {
+                Some(project_dir) => intergrations::gh::clone_repo(&selected_project, project_dir)?,
+                None => return Ok(()),
+            }
+            
         }
 
         intergrations::tmuxinator::run_tmuxinator(&selected_project, config.tmuxinator())?;
@@ -41,7 +47,7 @@ pub fn open_project(config: WorkflowsConfig) -> io::Result<()> {
 pub fn open_specific_project(project_name: String, config: WorkflowsConfig) -> io::Result<()> {
     let project_name = project_name.trim();
 
-    let local_projects = get_local_projects(config.general().projects_dir());
+    let local_projects = get_local_projects(config.general().projects_dirs());
 
     let matching_project = local_projects.iter().find(|x| x.name() == project_name);
 
@@ -62,26 +68,35 @@ pub fn open_specific_project(project_name: String, config: WorkflowsConfig) -> i
 /// # Returns
 ///
 /// A vec of strings containing the names of the directories in the project folder
-pub fn get_local_projects(project_dir: String) -> Vec<Repo> {
+pub fn get_local_projects(project_dirs: Vec<String>) -> Vec<Repo> {
     let home = dirs::home_dir().expect("Couldn't load home directory!");
-    let entries = match fs::read_dir(home.join(&project_dir)) {
-        Ok(entries) => entries,
-        Err(_) => {
-            fs::create_dir(home.join(&project_dir)).expect("Failed to create Projects directory");
-            fs::read_dir(home.join(&project_dir)).expect("Failed to read directroy")
-        }
-    };
 
-    let local_repos: Vec<Repo> = entries
-        .filter_map(|file| {
-            let path = file.ok()?.path();
-            if !path.is_dir() {
-                return None;
+    let mut local_repos = vec![];
+    
+    for project_dir in project_dirs {
+        let entries = match fs::read_dir(home.join(&project_dir)) {
+            Ok(entries) => entries,
+            Err(_) => {
+                fs::create_dir(home.join(&project_dir))
+                    .expect("Failed to create Projects directory");
+                fs::read_dir(home.join(&project_dir)).expect("Failed to read directroy")
             }
-            path.file_name()?
-                .to_str()
-                .map(|x| Repo::new(x, true, &project_dir))
-        })
-        .collect();
+        };
+
+        let mut dirs_projects: Vec<Repo> = entries
+            .filter_map(|file| {
+                let path = file.ok()?.path();
+                if !path.is_dir() {
+                    return None;
+                }
+                path.file_name()?
+                    .to_str()
+                    .map(|x| Repo::new(x, true, Some(&project_dir)))
+            })
+            .collect();
+
+        local_repos.append(&mut dirs_projects);
+    }
+
     local_repos
 }

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -13,7 +13,7 @@ use crate::repo::Repo;
 pub fn open_project(config: WorkflowsConfig) -> io::Result<()> {
     let selected_project = intergrations::fzf::run_fzf(&config.fzf().open_prompt(), false, &config);
 
-    if let Some(selected_project) = selected_project {
+    if let Some(mut selected_project) = selected_project {
         if !selected_project.local() {
             if config.github().confirm_cloning()
                 && !casual::prompt("Project is not local, clone it to ~/Projects/?")
@@ -26,7 +26,10 @@ pub fn open_project(config: WorkflowsConfig) -> io::Result<()> {
             }
 
             match get_project_dir(&config) {
-                Some(project_dir) => intergrations::gh::clone_repo(&selected_project, project_dir)?,
+                Some(project_dir) => {
+                    intergrations::gh::clone_repo(&selected_project, project_dir.clone())?;
+                    selected_project.set_project_dir(Some(project_dir));
+                },
                 None => return Ok(()),
             }
             

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -29,10 +29,9 @@ pub fn open_project(config: WorkflowsConfig) -> io::Result<()> {
                 Some(project_dir) => {
                     intergrations::gh::clone_repo(&selected_project, project_dir.clone())?;
                     selected_project.set_project_dir(Some(project_dir));
-                },
+                }
                 None => return Ok(()),
             }
-            
         }
 
         intergrations::tmuxinator::run_tmuxinator(&selected_project, config.tmuxinator())?;
@@ -75,7 +74,7 @@ pub fn get_local_projects(project_dirs: Vec<String>) -> Vec<Repo> {
     let home = dirs::home_dir().expect("Couldn't load home directory!");
 
     let mut local_repos = vec![];
-    
+
     for project_dir in project_dirs {
         let entries = match fs::read_dir(home.join(&project_dir)) {
             Ok(entries) => entries,

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -7,7 +7,7 @@ const DEFAULT_OPEN_NEW_PROJECTS: bool = true;
 #[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
 pub struct GeneralConfig {
     /// Where projects should be stored, relative path from the user's home
-    projects_dir: Option<String>,
+    projects_dirs: Option<Vec<String>>,
 
     /// Whether projects should be opened after they're created
     open_new_projects: Option<bool>,
@@ -15,10 +15,10 @@ pub struct GeneralConfig {
 
 impl GeneralConfig {
     /// Where projects should be stored, relative path from the user's home
-    pub fn projects_dir(&self) -> String {
-        self.projects_dir
+    pub fn projects_dirs(&self) -> Vec<String> {
+        self.projects_dirs
             .clone()
-            .unwrap_or(DEFAULT_PROJECTS_DIR.to_string())
+            .unwrap_or(vec![DEFAULT_PROJECTS_DIR.to_string()])
     }
 
     /// Whether projects should be opened after they're created
@@ -38,11 +38,14 @@ mod tests {
     fn projects_dir_works() {
         let toml = "\
 [general]
-projects_dir = 'Testing'";
+projects_dirs = ['Testing']";
 
         let config: WorkflowsConfig = toml::from_str(toml).expect("Failed to unwrap toml");
 
-        assert_eq!(config.general().projects_dir, Some("Testing".to_string()))
+        assert_eq!(
+            config.general().projects_dirs,
+            Some(vec!["Testing".to_string()])
+        )
     }
 
     #[test]
@@ -51,11 +54,25 @@ projects_dir = 'Testing'";
 
         let config: WorkflowsConfig = toml::from_str(toml).expect("Failed to unwrap toml");
 
-        assert_eq!(config.general.clone().unwrap().projects_dir, None);
+        assert_eq!(config.general.clone().unwrap().projects_dirs, None);
 
         assert_eq!(
-            config.general().projects_dir(),
-            DEFAULT_PROJECTS_DIR.to_string()
+            config.general().projects_dirs(),
+            vec![DEFAULT_PROJECTS_DIR.to_string()]
+        )
+    }
+
+    #[test]
+    fn multiple_projects_dirs_works() {
+        let toml = "\
+[general]
+projects_dirs = ['Projects/', '.config/']";
+
+        let config: WorkflowsConfig = toml::from_str(toml).expect("Failed to unwrap toml");
+
+        assert_eq!(
+            config.general().projects_dirs,
+            Some(vec!["Projects/".to_string(), ".config/".to_string()])
         )
     }
 

--- a/src/intergrations/fzf.rs
+++ b/src/intergrations/fzf.rs
@@ -126,7 +126,7 @@ pub fn get_project_dir(config: &WorkflowsConfig) -> Option<String> {
         return Some(projects_dirs[0].clone());
     }
 
-    let fzf = get_fzf_instance("Select a Project: ", config.fzf());
+    let fzf = get_fzf_instance("Select a Project Directory: ", config.fzf());
 
     fzf_wrapped::run_with_output(fzf, projects_dirs)
 }

--- a/src/intergrations/gh.rs
+++ b/src/intergrations/gh.rs
@@ -36,7 +36,7 @@ pub fn clone_repo(repo: &Repo, project_dir: String) -> io::Result<()> {
 /// # Returns
 ///
 /// A vec of repo structs
-pub fn get_gh_repos(local_projects: &[Repo], project_dir: String) -> Vec<Repo> {
+pub fn get_gh_repos(local_projects: &[Repo]) -> Vec<Repo> {
     let output = Command::new("gh")
         .args(["repo", "list", "--limit", "1000"])
         .output()
@@ -57,7 +57,7 @@ pub fn get_gh_repos(local_projects: &[Repo], project_dir: String) -> Vec<Repo> {
             .iter()
             .filter_map(|repo_string| {
                 let name = repo_string.split('/').nth(1);
-                name.map(|name| Repo::new(name, false, &project_dir))
+                name.map(|name| Repo::new(name, false, None))
             })
             .filter(|repo| !repo.name().is_empty() && !local_projects.contains(repo))
             .collect();

--- a/src/intergrations/git.rs
+++ b/src/intergrations/git.rs
@@ -39,7 +39,9 @@ pub fn clone_repo(url: &str, config: &WorkflowsConfig) -> io::Result<String> {
 ///
 /// Always returns false if the user is not connected to the internet
 pub fn repo_pushed(repo: &Repo) -> io::Result<PushedResult> {
-    let repo_dir = repo.get_project_root().expect("Failed to get the projects root");
+    let repo_dir = repo
+        .get_project_root()
+        .expect("Failed to get the projects root");
 
     let output = Command::new("git")
         .current_dir(repo_dir)
@@ -58,7 +60,9 @@ pub fn repo_pushed(repo: &Repo) -> io::Result<PushedResult> {
 
 /// Checks if the repo has a clean working tree
 pub fn repo_clean_tree(repo: &Repo) -> io::Result<bool> {
-    let repo_dir = repo.get_project_root().expect("Failed to get the project root");
+    let repo_dir = repo
+        .get_project_root()
+        .expect("Failed to get the project root");
 
     let output = Command::new("git")
         .current_dir(repo_dir)

--- a/src/intergrations/git.rs
+++ b/src/intergrations/git.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    process::{Command, Stdio}, path::PathBuf,
+    process::{Command, Stdio},
 };
 
 use crate::{config::WorkflowsConfig, repo::Repo};
@@ -17,13 +17,13 @@ pub enum PushedResult {
 ///
 /// # Returns
 ///
-/// An IO error if the repo doesn't exist, otherwise the project directory it was cloned to
-pub fn clone_repo(url: &str, config: &WorkflowsConfig) -> io::Result<PathBuf> {
+/// An IO error if the repo doesn't exist, otherwise the selected project_dir
+pub fn clone_repo(url: &str, config: &WorkflowsConfig) -> io::Result<String> {
     let project_dir = get_project_dir(config).expect("Failed to get a directory");
 
     let clone_dir = dirs::home_dir()
         .expect("Failed to get home dir")
-        .join(project_dir);
+        .join(project_dir.clone());
 
     let mut command = Command::new("git")
         .current_dir(clone_dir.clone())
@@ -32,7 +32,7 @@ pub fn clone_repo(url: &str, config: &WorkflowsConfig) -> io::Result<PathBuf> {
         .spawn()?;
 
     command.wait()?;
-    Ok(clone_dir)
+    Ok(project_dir)
 }
 
 /// Checks if the repo has every commit pushed

--- a/src/intergrations/git.rs
+++ b/src/intergrations/git.rs
@@ -1,9 +1,11 @@
 use std::{
     io,
-    process::{Command, Stdio},
+    process::{Command, Stdio}, path::PathBuf,
 };
 
-use crate::{config::general::GeneralConfig, repo::Repo};
+use crate::{config::WorkflowsConfig, repo::Repo};
+
+use super::fzf::get_project_dir;
 
 /// Represents the possible outcomes of the repo_pushed() function
 pub enum PushedResult {
@@ -15,27 +17,29 @@ pub enum PushedResult {
 ///
 /// # Returns
 ///
-/// An IO error if the repo doesn't exist, otherwise `Ok(())`
-pub fn clone_repo(url: &str, config: &GeneralConfig) -> io::Result<()> {
+/// An IO error if the repo doesn't exist, otherwise the project directory it was cloned to
+pub fn clone_repo(url: &str, config: &WorkflowsConfig) -> io::Result<PathBuf> {
+    let project_dir = get_project_dir(config).expect("Failed to get a directory");
+
     let clone_dir = dirs::home_dir()
         .expect("Failed to get home dir")
-        .join(config.projects_dir());
+        .join(project_dir);
 
     let mut command = Command::new("git")
-        .current_dir(clone_dir)
+        .current_dir(clone_dir.clone())
         .args(["clone", url])
         .stdout(Stdio::piped())
         .spawn()?;
 
     command.wait()?;
-    Ok(())
+    Ok(clone_dir)
 }
 
 /// Checks if the repo has every commit pushed
 ///
 /// Always returns false if the user is not connected to the internet
 pub fn repo_pushed(repo: &Repo) -> io::Result<PushedResult> {
-    let repo_dir = repo.get_project_root();
+    let repo_dir = repo.get_project_root().expect("Failed to get the projects root");
 
     let output = Command::new("git")
         .current_dir(repo_dir)
@@ -54,7 +58,7 @@ pub fn repo_pushed(repo: &Repo) -> io::Result<PushedResult> {
 
 /// Checks if the repo has a clean working tree
 pub fn repo_clean_tree(repo: &Repo) -> io::Result<bool> {
-    let repo_dir = repo.get_project_root();
+    let repo_dir = repo.get_project_root().expect("Failed to get the project root");
 
     let output = Command::new("git")
         .current_dir(repo_dir)

--- a/src/intergrations/tmuxinator.rs
+++ b/src/intergrations/tmuxinator.rs
@@ -88,7 +88,8 @@ windows:",
             .expect("Failed to cast pathbuf to string"),
         project.name(),
         project
-            .get_project_root().expect("Failed to get the projects root")
+            .get_project_root()
+            .expect("Failed to get the projects root")
             .to_str()
             .expect("Failed to cast pathbuf to string"),
     );
@@ -186,7 +187,8 @@ windows:
                     .expect("Failed to cast pathbuf to string"),
                 project.name(),
                 project
-                    .get_project_root().unwrap()
+                    .get_project_root()
+                    .unwrap()
                     .to_str()
                     .expect("Failed to cast pathbuf to string"),
             )
@@ -223,7 +225,8 @@ windows:
                     .expect("Failed to cast pathbuf to string"),
                 project.name(),
                 project
-                    .get_project_root().unwrap()
+                    .get_project_root()
+                    .unwrap()
                     .to_str()
                     .expect("Failed to cast pathbuf to string"),
                 DEFAULT_START_COMMAND

--- a/src/intergrations/tmuxinator.rs
+++ b/src/intergrations/tmuxinator.rs
@@ -88,7 +88,7 @@ windows:",
             .expect("Failed to cast pathbuf to string"),
         project.name(),
         project
-            .get_project_root()
+            .get_project_root().expect("Failed to get the projects root")
             .to_str()
             .expect("Failed to cast pathbuf to string"),
     );
@@ -165,7 +165,7 @@ mod tests {
 
         let config: WorkflowsConfig = toml::from_str(toml).unwrap();
 
-        let project = Repo::new("test-repo", true, "Projects/test-repo");
+        let project = Repo::new("test-repo", true, Some("Projects/test-repo"));
 
         let generated_config = get_config_contents(&project, config.tmuxinator());
 
@@ -186,7 +186,7 @@ windows:
                     .expect("Failed to cast pathbuf to string"),
                 project.name(),
                 project
-                    .get_project_root()
+                    .get_project_root().unwrap()
                     .to_str()
                     .expect("Failed to cast pathbuf to string"),
             )
@@ -202,7 +202,7 @@ windows:
 
         let config: WorkflowsConfig = toml::from_str(toml).unwrap();
 
-        let project = Repo::new("test-repo", true, "Projects/test-repo");
+        let project = Repo::new("test-repo", true, Some("Projects/test-repo"));
 
         let generated_config = get_config_contents(&project, config.tmuxinator());
 
@@ -223,7 +223,7 @@ windows:
                     .expect("Failed to cast pathbuf to string"),
                 project.name(),
                 project
-                    .get_project_root()
+                    .get_project_root().unwrap()
                     .to_str()
                     .expect("Failed to cast pathbuf to string"),
                 DEFAULT_START_COMMAND

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ fn main() -> io::Result<()> {
 
     if args.contains(&"--new".to_string()) || args.contains(&"-n".to_string()) {
         let project = commands::new_project(args.get(2).cloned(), config.clone())?;
-        if let Some(project) = project {
-            let project = repo::Repo::new(project, true, config.general().projects_dir());
+        if let Some((project, project_dir)) = project {
+            let project = repo::Repo::new(project, true, Some(project_dir));
 
             println!("Project {} created successfully!", project.name());
 
@@ -42,7 +42,7 @@ fn main() -> io::Result<()> {
     }
 
     if args.contains(&"--clone".to_string()) || args.contains(&"-c".to_string()) {
-        let repo = commands::git_clone(args.get(2).cloned(), config.general());
+        let repo = commands::git_clone(args.get(2).cloned(), &config);
         if let Some(repo) = repo {
             return intergrations::tmuxinator::run_tmuxinator(&repo, config.tmuxinator());
         }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -10,7 +10,7 @@ pub struct Repo {
     /// Whether the project is local or not
     local: bool,
     /// The path to the projects directory
-    project_dir: String,
+    project_dir: Option<String>,
 }
 
 impl PartialEq for Repo {
@@ -31,9 +31,11 @@ impl Repo {
     /// # Returns
     ///
     /// A Repo struct
-    pub fn new<T: Into<String>>(name: T, local: bool, project_dir: T) -> Self {
+    pub fn new<T: Into<String>>(name: T, local: bool, project_dir: Option<T>) -> Self {
         let name = name.into();
-        let project_dir = project_dir.into();
+
+        let project_dir = project_dir.map(|project_dir| project_dir.into());
+
         Self {
             name,
             local,
@@ -72,11 +74,12 @@ impl Repo {
     /// # Returns
     ///
     /// A path buf to ~/<project_dir>/<projectname>
-    pub fn get_project_root(&self) -> PathBuf {
-        dirs::home_dir()
-            .expect("Couldn't get home directory")
-            .join(self.project_dir.as_str())
-            .join(format!("{}/", self.name))
+    pub fn get_project_root(&self) -> Option<PathBuf> {
+        let project_root = dirs::home_dir()?
+            .join(self.project_dir.clone()?)
+            .join(format!("{}/", self.name));
+
+        Some(project_root)
     }
 }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// This struct represents a project
 ///
 /// Terminology used is `Repo` as in theory it's a git repo
@@ -80,6 +80,10 @@ impl Repo {
             .join(format!("{}/", self.name));
 
         Some(project_root)
+    }
+
+    pub fn set_project_dir(&mut self, project_dir: Option<String>) {
+        self.project_dir = project_dir;
     }
 }
 


### PR DESCRIPTION
- Added support for multiple project directories
- Added fzf interface for selecting project directories

BREAKING CHANGE: `projects_dir` is no longer a valid config option, has been replaces with `projects_dirs` which takes a vector of strings

Closes #14 