### PR TITLE
feat: add --list command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,14 @@
+@default:
+    just --list
+
+# Runs the project with cargo run
+dev:
+    cargo run
+
+# Formats the project
+fmt:
+    cargo fmt
+
+# Runs clippy
+check:
+    cargo clippy

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -14,6 +14,7 @@ Commands
   --clone     -c   Clones the git repo from the given URL and opens it using workflows
   --borrow    -b   Clones a github project, prompting deletion after the session is closed
   --delete    -d   Deletes the given project from the local machine
+  --list      -l   Shows all local projects grouped under the parent dir. Optional param for filtering
   --health         Checks that workflows can access the required programs
   --help      -h   Show this dialog
 ",

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -8,18 +8,31 @@ use crate::{commands::open::get_local_project, config::WorkflowsConfig};
 ///
 /// # Parameters
 ///
+/// - `project_dir_filter` The passed in project diretory filter
 /// - `config` The user's config
-pub fn list_projects(config: WorkflowsConfig) -> io::Result<()> {
-    for project_dir in config.general().projects_dirs() {
-        println!("{}", project_dir.bold());
+pub fn list_projects(
+    project_dir_filter: Option<String>,
+    config: WorkflowsConfig,
+) -> io::Result<()> {
+    config
+        .general()
+        .projects_dirs()
+        .iter()
+        .filter(|x| {
+            project_dir_filter.is_none()
+                || x.to_lowercase()
+                    .contains(&project_dir_filter.clone().unwrap().to_lowercase())
+        })
+        .for_each(|project_dir| {
+            println!("{}", project_dir.bold());
 
-        get_local_project(project_dir)
-            .iter()
-            .map(|x| format!("• {}", x.name()))
-            .for_each(|x| println!("{}", x));
+            get_local_project(project_dir.to_string())
+                .iter()
+                .map(|x| format!("• {}", x.name()))
+                .for_each(|x| println!("{}", x));
 
-        println!();
-    }
+            println!();
+        });
 
     Ok(())
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,25 @@
+use std::io;
+
+use colored::*;
+
+use crate::{commands::open::get_local_project, config::WorkflowsConfig};
+
+/// Lists all local projects under their project directory
+///
+/// # Parameters
+///
+/// - `config` The user's config
+pub fn list_projects(config: WorkflowsConfig) -> io::Result<()> {
+    for project_dir in config.general().projects_dirs() {
+        println!("{}", project_dir.bold());
+
+        get_local_project(project_dir)
+            .iter()
+            .map(|x| format!("• {}", x.name()))
+            .for_each(|x| println!("{}", x));
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,3 +25,6 @@ pub use clone::git_clone;
 
 mod borrow;
 pub use borrow::borrow_project;
+
+mod list;
+pub use list::list_projects;

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -74,8 +74,7 @@ pub fn open_specific_project(project_name: String, config: WorkflowsConfig) -> i
 pub fn get_local_projects(project_dirs: Vec<String>) -> Vec<Repo> {
     project_dirs
         .iter()
-        .map(|x| get_local_project(x.to_string()))
-        .flatten()
+        .flat_map(|x| get_local_project(x.to_string()))
         .collect()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,5 +59,9 @@ fn main() -> io::Result<()> {
         return commands::borrow_project(config);
     }
 
+    if args.contains(&"--list".to_string()) || args.contains(&"-l".to_string()) {
+        return commands::list_projects(config);
+    }
+
     commands::open_project(config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,8 @@ fn main() -> io::Result<()> {
     }
 
     if args.contains(&"--list".to_string()) || args.contains(&"-l".to_string()) {
-        return commands::list_projects(config);
+        let project_dir_filter = args.get(2).cloned();
+        return commands::list_projects(project_dir_filter, config);
     }
 
     commands::open_project(config)


### PR DESCRIPTION
Lists all projects in the project directories. Also allows filtering, for example

```
workflows --list projects
Projects/
• ws-test
• wails-test
• tov-solutions
• Uni-Notebook
• mithril-tutorial
• workflows
• library-collection
• zenchess
• mithril-go-test
• nix-config

```